### PR TITLE
Allow configuration of failure thresholds and pod management policy

### DIFF
--- a/solr/templates/statefulset.yaml
+++ b/solr/templates/statefulset.yaml
@@ -171,6 +171,7 @@ spec:
           livenessProbe:
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
             httpGet:
               scheme: "{{ .Values.tls.enabled | ternary "HTTPS" "HTTP" }}"
@@ -179,6 +180,7 @@ spec:
           readinessProbe:
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
             httpGet:
               scheme: "{{ .Values.tls.enabled | ternary "HTTPS" "HTTP" }}"

--- a/solr/templates/statefulset.yaml
+++ b/solr/templates/statefulset.yaml
@@ -14,6 +14,7 @@ spec:
       release: "{{ .Release.Name }}"
       component: "server"
   serviceName: {{ template "solr.headless-service-name" . }}
+  podManagementPolicy: "{{ .Values.podManagementPolicy }}"
   replicas: {{ .Values.replicaCount }}
   updateStrategy:
     {{ toYaml .Values.updateStrategy | indent 4}}
@@ -170,6 +171,7 @@ spec:
           livenessProbe:
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
             httpGet:
               scheme: "{{ .Values.tls.enabled | ternary "HTTPS" "HTTP" }}"
               path: /solr/admin/info/system
@@ -177,6 +179,7 @@ spec:
           readinessProbe:
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
             httpGet:
               scheme: "{{ .Values.tls.enabled | ternary "HTTPS" "HTTP" }}"
               path: /solr/admin/info/system

--- a/solr/values.yaml
+++ b/solr/values.yaml
@@ -6,6 +6,9 @@ port: 8983
 # Number of solr instances to run
 replicaCount: 3
 
+# Pod Management Policy for solr
+podManagementPolicy: "OrderedReady"
+
 # Settings for solr java memory
 javaMem: "-Xms2g -Xmx3g"
 
@@ -26,11 +29,13 @@ image:
 livenessProbe:
   initialDelaySeconds: 20
   periodSeconds: 10
+  failureThreshold: 3
 
 # Solr pod readiness
 readinessProbe:
   initialDelaySeconds: 15
   periodSeconds: 5
+  failureThreshold: 3
 
 # Annotations to apply to the solr pods
 podAnnotations: {}

--- a/solr/values.yaml
+++ b/solr/values.yaml
@@ -30,12 +30,14 @@ livenessProbe:
   initialDelaySeconds: 20
   periodSeconds: 10
   failureThreshold: 3
+  timeoutSeconds: 1
 
 # Solr pod readiness
 readinessProbe:
   initialDelaySeconds: 15
   periodSeconds: 5
   failureThreshold: 3
+  timeoutSeconds: 1
 
 # Annotations to apply to the solr pods
 podAnnotations: {}


### PR DESCRIPTION
Note, the defaults are same as previous behavior. This commit just
allows for customization of these settings via helm.